### PR TITLE
Typo Error: Class word fixed and Solution Added

### DIFF
--- a/binary search/elementAppearsOnlyOnceInSortedArray.java
+++ b/binary search/elementAppearsOnlyOnceInSortedArray.java
@@ -1,4 +1,4 @@
-lass Sol
+class Solution
 {
     public static int search(int a[], int n)
     {


### PR DESCRIPTION
There was a typo in-class word and sol was changed to solution for better readability.